### PR TITLE
Update bh.R

### DIFF
--- a/AdultCoverage/R/DDM/R/bh.R
+++ b/AdultCoverage/R/DDM/R/bh.R
@@ -616,7 +616,7 @@ ggbsegCoverageFromYear <- function(codi,
 	                              agesFit.ggb = agesFit.ggb,
 	                              deaths.summed = deaths.summed)
 	} else {
-	  agesFit.ggbseg <- agesFit.ggbseg
+	  agesFit.ggbseg <- exact.ages.seg
 	}
 	# TODO: TR: make this function take two exact.ages args (exact.ages.ggb and exact.ages.seg)
 	# by default equal, but potentially different if desired. Per Ken Hill recommendations 


### PR DESCRIPTION
Hi Tim,

I'm not sure if it is correct, but I changed Line 619 to 

agesFit.ggbseg <- exact.ages.seg

to remove an error I had been getting when using the ggbseg() with pre-specified age ranges. For example,

ggbseg(BrasilFemales,
       exact.ages.ggb=c(20, 65),
       exact.ages.seg=c(15, 70))

works now, but it gave me an error with the previous version of bh.R.

Thanks for the update!


-Jeremy

